### PR TITLE
Generic arduino adc streaming

### DIFF
--- a/python/asciiserialcom/base.py
+++ b/python/asciiserialcom/base.py
@@ -261,7 +261,7 @@ class Base:
                                 f"Received message with unrecognized command: {msg}"
                             )
         except FileReadError as e:
-            logging.warning("FileReadError while reading from serial port")
+            logging.debug("FileReadError while reading from serial port")
         except trio.Cancelled as e:
             logging.debug(f"Cancellation happened")
             raise e

--- a/src/avr/Makefile
+++ b/src/avr/Makefile
@@ -2,7 +2,7 @@ attiny817firmware=src/avr/attiny817_xplained_blink
 
 attiny3217firmware=src/avr/attiny3217_cnano_blink
 
-atmega328pfirmware=src/avr/arduino_uno_blink src/avr/arduino_uno_blink_interrupt src/avr/arduino_uno_char_loopback src/avr/arduino_uno_cb_loopback src/avr/arduino_uno_asc_loopback src/avr/arduino_uno_dummy_register_block src/avr/arduino_uno_register_pointers src/avr/arduino_uno_write_pattern_to_serial src/avr/arduino_uno_write_message_to_serial src/avr/arduino_uno_asc_write_pattern_to_serial src/avr/arduino_uno_test_device
+atmega328pfirmware=src/avr/arduino_uno_blink src/avr/arduino_uno_blink_interrupt src/avr/arduino_uno_char_loopback src/avr/arduino_uno_cb_loopback src/avr/arduino_uno_asc_loopback src/avr/arduino_uno_dummy_register_block src/avr/arduino_uno_register_pointers src/avr/arduino_uno_write_pattern_to_serial src/avr/arduino_uno_write_message_to_serial src/avr/arduino_uno_asc_write_pattern_to_serial src/avr/arduino_uno_test_device src/avr/arduino_uno_adc_streaming
 
 atmega2560firmware=src/avr/arduino_mega2560_blink
 

--- a/src/avr/arduino_uno_adc_streaming.c
+++ b/src/avr/arduino_uno_adc_streaming.c
@@ -1,3 +1,27 @@
+/*
+ * Uses timer to set interval between ADC single conversions that are then sent
+ * as stream messages to host.
+ *
+ * On receiving 'n' message, begins streaming ADC values to host (by default the
+ * ADC is connected to ground) Stops when 'f' message is received.
+ *
+ * ADC channel selection and time between ADC conversions are configurable with
+ * registers. I'm not quite sure what the units of timer counter compare are.
+ *
+ * Register map:
+ *
+ * 0: PORTB, only bit 5 is writable (the user LED)
+ * 1: lower 8 bits of the timer counter (read only)
+ * 2: upper 8 bits of the timer counter (read only)
+ * 3: lower 8 bits of the timer counter compare (r/w) default: 25
+ * 4: upper 8 bits of the timer counter compare (r/w) default: 0
+ * 5: ADMUX: the upper half of the register is the read only ADC reference
+ * selection the bottom 4 bits are r/w and are the channel selection, default:
+ * 0xF values of 0-7 select the ADC channel to read from and 0xF is GND Don't
+ * write any values besides 0-7 and 0xF, as it could cause issues.
+ *
+ */
+
 #include "asc_exception.h"
 #include "ascii_serial_com.h"
 #include "ascii_serial_com_device.h"

--- a/src/avr/arduino_uno_adc_streaming.c
+++ b/src/avr/arduino_uno_adc_streaming.c
@@ -1,0 +1,138 @@
+#include "asc_exception.h"
+#include "ascii_serial_com.h"
+#include "ascii_serial_com_device.h"
+#include "ascii_serial_com_register_pointers.h"
+#include "avr/avr_uart.h"
+#include "circular_buffer.h"
+
+#include <avr/interrupt.h>
+#include <avr/io.h>
+#include <util/atomic.h>
+
+#define F_CPU 16000000L
+#define BAUD 9600
+#define MYUBRR (F_CPU / 16 / BAUD - 1)
+
+char dataBuffer[MAXDATALEN];
+#define nRegs 3
+volatile REGTYPE *regPtrs[nRegs] = {&PORTB, &PORTC, &PORTD};
+
+REGTYPE masks[nRegs] = {
+    1 << 5,
+    0,
+    0,
+};
+
+typedef struct stream_state_struct {
+  uint8_t on;
+} on_off_stream_state;
+void handle_nf_messages(ascii_serial_com *asc, char ascVersion, char appVersion,
+                        char command, char *data, size_t dataLen,
+                        void *state_vp);
+
+on_off_stream_state stream_state;
+
+ascii_serial_com_device ascd;
+ascii_serial_com_register_pointers reg_pointers_state;
+ascii_serial_com_device_config ascd_config = {
+    .func_rw = ascii_serial_com_register_pointers_handle_message,
+    .state_rw = &reg_pointers_state,
+    .func_nf = handle_nf_messages,
+    .state_nf = &stream_state};
+
+#define extraInputBuffer_size 64
+uint8_t extraInputBuffer_raw[extraInputBuffer_size];
+circular_buffer_uint8 extraInputBuffer;
+
+CEXCEPTION_T e;
+
+uint16_t nExceptions;
+uint8_t counter;
+char counter_buffer[2];
+
+int main(void) {
+
+  DDRB |= 1 << 5;
+
+  // Use Tim0 interrupts to time ADC conversions
+  // Tim0 in normal mode, which is default
+  // Output compare is the interrupt
+  // Bottom 3 bits of TCCR0B control clock prescaling
+  //    0b101 = 0x5 is the lowest speed, clk/1024
+  //    Setting this to != 0 is what enables the timer
+  // The timer count can be access/modified at TCNT0
+  // OCR0A sets the value for output compare unit A
+  // TIMSK0: timer interrupt enable mask, bit OCIE0A enables output compare unit
+  // A Don't have to clear the interrupt flag manually, it's done automatically
+  // It's the same with Tim1, it's just 16 bit
+
+  nExceptions = 0;
+  stream_state.on = 0;
+  counter = 0;
+
+  ascii_serial_com_register_pointers_init(&reg_pointers_state, regPtrs, masks,
+                                          nRegs);
+  ascii_serial_com_device_init(&ascd, &ascd_config);
+  circular_buffer_uint8 *asc_in_buf =
+      ascii_serial_com_device_get_input_buffer(&ascd);
+  circular_buffer_uint8 *asc_out_buf =
+      ascii_serial_com_device_get_output_buffer(&ascd);
+
+  circular_buffer_init_uint8(&extraInputBuffer, extraInputBuffer_size,
+                             extraInputBuffer_raw);
+
+  USART0_Init(MYUBRR, 1);
+
+  sei();
+
+  while (true) {
+    Try {
+      // if (USART0_can_read_Rx_data) {
+      //  circular_buffer_push_back_uint8(asc_in_buf, UDR0);
+      //}
+
+      if (!circular_buffer_is_empty_uint8(&extraInputBuffer)) {
+        uint8_t byte;
+        ATOMIC_BLOCK(ATOMIC_FORCEON) {
+          byte = circular_buffer_pop_front_uint8(&extraInputBuffer);
+        }
+        circular_buffer_push_back_uint8(asc_in_buf, byte);
+      }
+
+      ascii_serial_com_device_receive(&ascd);
+
+      if (stream_state.on && circular_buffer_get_size_uint8(asc_out_buf) == 0) {
+        convert_uint8_to_hex(counter, counter_buffer, true);
+        ascii_serial_com_device_put_s_message_in_output_buffer(
+            &ascd, '0', '0', counter_buffer, 2);
+        counter++;
+      }
+      if (circular_buffer_get_size_uint8(asc_out_buf) > 0 &&
+          USART0_can_write_Tx_data) {
+        UDR0 = circular_buffer_pop_front_uint8(asc_out_buf);
+      }
+    }
+    Catch(e) { nExceptions++; }
+  }
+
+  return 0;
+}
+
+ISR(USART_RX_vect) {
+  char c = UDR0;
+  circular_buffer_push_back_uint8(&extraInputBuffer, c);
+}
+
+void handle_nf_messages(__attribute__((unused)) ascii_serial_com *asc,
+                        __attribute__((unused)) char ascVersion,
+                        __attribute__((unused)) char appVersion, char command,
+                        __attribute__((unused)) char *data,
+                        __attribute__((unused)) size_t dataLen,
+                        void *state_vp) {
+  on_off_stream_state *state = (on_off_stream_state *)state_vp;
+  if (command == 'n') {
+    state->on = 1;
+  } else if (command == 'f') {
+    state->on = 0;
+  }
+}

--- a/src/avr/arduino_uno_adc_streaming.c
+++ b/src/avr/arduino_uno_adc_streaming.c
@@ -79,7 +79,11 @@ int main(void) {
   TCCR0B |= 0x5;         // enable timer with clk/1024
 
   // ADC
-  // ADMUX top 2 bits select reference. Default is AREF
+  // ADMUX top 2 bits select reference. Default (0b00xxxxxx) is AREF--I think
+  // that means whatever is applied to the AREF pin
+  //    0b01xxxxxx selects AVCC (which is then connected to AREF so be careful
+  //    with what's hooked there) 0b11xxxxxx selects internal 1.1V reference
+  //    (which is then connected to AREF so be careful with what's hooked there)
   // ADMUX bottom 4 bits select channels 0 through 8 as just ints
   // ADMUX bottom 4 bits should be 0xF for ground and 0xE for bandgap (don't
   // use) ADCSRA Status and control reg A bits:
@@ -91,7 +95,8 @@ int main(void) {
   //            for us at 16MHz, that means we need the /128 which is 0b111 = 7
   // ADC data for 16 bit reads is at "ADC"
   // DIDR0 diables digial inputs for ADC0-5 if they are being used
-  ADMUX = 0xF;         // select ADC input
+  ADMUX = 0x40;        // select AVCC as reference
+  ADMUX |= 0xF;        // select ADC input
   ADCSRA = 7;          // set ADC clock prescaler
   ADCSRA |= 1 << ADEN; // enable ADC
 


### PR DESCRIPTION
Resolves #28 

Adds new firmware `arduino_uno_adc_streaming` that uses a timer for the interval between ADC single conversions that are then sent as stream messages to the host. The ADC multiplexer and counter compare are accessible registers.

Timing isn't super consistent, and the ADC has only been tested hooked up to ground, 3.3 V, and 5 V.